### PR TITLE
Update funding & issue templates

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-# github: shgysk8zer0
+github: shgysk8zer0
 liberapay: shgysk8zer0

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,11 +2,9 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
-assignees: ''
-
+labels: 'bug'
+assignees: 'shgysk8zer0'
 ---
-
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,11 +2,9 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
-assignees: ''
-
+labels: 'enhancement'
+assignees: 'shgysk8zer0'
 ---
-
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 


### PR DESCRIPTION
- Add GitHub Sponsors option to funding
- Add label & assignee to issue templates

GitHub Sponsors isn't fully setup yet, but worth including in a template repository anyways for when it is.