### PR TITLE
Disable markdown linting in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<!-- markdownlint-disable -->
+## [1.0.2] 2020-06-19
+### Changed
+- Disabled markdown linting of releases section in `CHANGELOG.md`
 
 ## [1.0.1] 2020-06-19
 ### Added
@@ -24,3 +28,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] 2020-05-12
 Initial Version Release
+<!-- markdownlint-restore -->


### PR DESCRIPTION
- Disabled markdown linting of releases section in `CHANGELOG.md`