### PR TITLE
Fix issues in README & service worker config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 <!-- markdownlint-disable -->
+## [v1.0.6] - 2020-06-27
+
+### Fixed
+- Fix invalid script src for `<button is="pwa-install">` [#63](https://github.com/shgysk8zer0/jekyll-template/issues/63)
+- Update Node CI status badge in README [#62](https://github.com/shgysk8zer0/jekyll-template/issues/62)
+
+### Removed
+- Dependabot status badge, since not supported by v2
+
 ## [v1.0.5] 2020-06-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix invalid script src for `<button is="pwa-install">` [#63](https://github.com/shgysk8zer0/jekyll-template/issues/63)
 - Update Node CI status badge in README [#62](https://github.com/shgysk8zer0/jekyll-template/issues/62)
+- Allow GitHub avatars & BaconIpsum API in CSP
 
 ### Removed
 - Dependabot status badge, since not supported by v2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # jekyll-template
 A template repository for Jekyll sites, including skeleton JS, CSS, SVGs, fonts, etc.
 
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=shgysk8zer0/jekyll-template)](https://dependabot.com)
-[![Node CI](https://github.com/shgysk8zer0/static-template/workflows/Node%20CI/badge.svg)](https://github.com/shgysk8zer0/static-template/actions)
+<!-- [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=shgysk8zer0/jekyll-template)](https://dependabot.com) -->
+[![Node CI](https://github.com/shgysk8zer0/jekyll-template/workflows/Node%20CI/badge.svg)](https://github.com/shgysk8zer0/jekyll-template/actions)
 [![Super Linter](https://github.com/shgysk8zer0/jekyll-template/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/shgysk8zer0/jekyll-template/actions?query=workflow%3A%22Lint+Code+Base%22)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/252539d1-4596-41e9-9d63-97a964822b25/deploy-status)](https://app.netlify.com/sites/infallible-galileo-ac41ee/deploys)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,10 +21,10 @@
     Content-Security-Policy = '''
       default-src 'self';
       base-uri 'self';
-      img-src 'self' https://i.imgur.com https://cdn.kernvalley.us https://secure.gravatar.com https://maps.wikimedia.org/osm-intl/ https://via.placeholder.com https://*.githubusercontent.com/;
+      img-src 'self' https://i.imgur.com https://*.githubusercontent.com/u/ https://cdn.kernvalley.us https://secure.gravatar.com https://maps.wikimedia.org/osm-intl/ https://via.placeholder.com https://*.githubusercontent.com/;
       script-src 'self' moz-extension: https://cdn.kernvalley.us https://unpkg.com/ https://www.google-analytics.com/ https://www.googletagmanager.com https://polyfill.io/ https://cdn.polyfill.io/ https://www.youtube.com/ https://www.youtube-nocookie.com/;
       style-src 'self' 'unsafe-inline' https://cdn.kernvalley.us https://unpkg.com/ https://fonts.googleapis.com/ https://www.youtube.com/ https://www.youtube-nocookie.com/;
-      connect-src 'self' https://cdn.kernvalley.us https://api.kernvalley.us https://api.github.com/ https://unpkg.com/ https://polyfill.io/ https://cdn.polyfill.io/ https://www.google-analytics.com/ https://www.googletagmanager.com/ https://i.imgur.com https://secure.gravatar.com https://maps.wikimedia.org/osm-intl/ https://fonts.gstatic.com/  https://fonts.googleapis.com/ https://via.placeholder.com;
+      connect-src 'self' https://baconipsum.com/api/ https://*.githubusercontent.com/u/ https://cdn.kernvalley.us https://api.kernvalley.us https://api.github.com/ https://unpkg.com/ https://polyfill.io/ https://cdn.polyfill.io/ https://www.google-analytics.com/ https://www.googletagmanager.com/ https://i.imgur.com https://secure.gravatar.com https://maps.wikimedia.org/osm-intl/ https://fonts.gstatic.com/  https://fonts.googleapis.com/ https://via.placeholder.com;
       font-src 'self' https://cdn.kernvalley.us https://fonts.gstatic.com/;
       media-src 'none';
       frame-src https://www.youtube.com https://www.youtube-nocookie.com https://disqus.com;

--- a/sw-config.js
+++ b/sw-config.js
@@ -24,7 +24,7 @@ const config = {
 
 		/* JS, `customElements`, etc. */
 		'https://polyfill.io/v3/polyfill.min.js',
-		'https://cdn.kernvalley.us/components/pwa-install.js',
+		'https://cdn.kernvalley.us/components/pwa/install.js',
 
 		/* CSS */
 		'https://unpkg.com/leaflet@1.6.0/dist/leaflet.css',

--- a/sw-config.js
+++ b/sw-config.js
@@ -39,7 +39,6 @@ const config = {
 		'https://cdn.kernvalley.us/img/adwaita-icons/actions/mail-send.svg',
 		'https://cdn.kernvalley.us/img/adwaita-icons/actions/mark-location.svg',
 		'https://cdn.kernvalley.us/img/octicons/file-media.svg',
-		'https://avatars2.githubusercontent.com/u/1627459?v=4&s=64',
 
 		/* Social Icons for Web Share API shim */
 		'https://cdn.kernvalley.us/img/octicons/mail.svg',


### PR DESCRIPTION
- Fix Node CI status badge. Resolves #62 
- Fix pwa-install button script src. Resolves #63 
- Remove Dependabot status badge, since not available for v2
- Update CSP to allow GitHub avatars & BaconIpsum API