### PR TITLE
Update eslint config for indentation on `switch`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,10 @@
     "rules": {
         "indent": [
             2,
-            "tab"
+            "tab",
+            {
+              "SwitchCase": 1
+            }
         ],
         "quotes": [
             2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.12] - 2020-07-17
+
 ### Updated
 - eslint now indents on each `case` for a `switch`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+- eslint now indents on each `case` for a `switch`
+
 ## [v1.0.12] - 2020-07-13
 
 ### Added


### PR DESCRIPTION
### Updated
- eslint now indents on each `case` for a `switch`