### PR TITLE
Remove trailing "/" from `site.url`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 author: Chris Zuber
 title: Jekyll Template Demo
-url: 'https://infallible-galileo-ac41ee.netlify.app/'
+url: 'https://infallible-galileo-ac41ee.netlify.app'
 markdown: kramdown
 version: 1.0.0
 timezone: America/Los_Angeles


### PR DESCRIPTION
This fixes `absolute_url` ending in "//" instead of "/"